### PR TITLE
Transaction info card

### DIFF
--- a/frontend/src/app/(private)/dashboard/page.tsx
+++ b/frontend/src/app/(private)/dashboard/page.tsx
@@ -11,6 +11,7 @@ import { useUserStore } from "@/src/store/useUserStore";
 import { useBankStore } from "@/src/store/useBankStore";
 
 import { LoaderIcon } from "@/src/assets/icons/LoaderCircleIcon";
+import TransactionInfoCard from "@/src/components/ui/TransactionInfoCard";
 import DashboardMoneyCard from "@/src/components/ui/DashboardMoneyCard";
 import ReminderModal from "@/src/components/forms/ReminderModal";
 import RemindersCard from "@/src/components/ui/RemindersCard";
@@ -140,7 +141,7 @@ export default function DashboardPage() {
 
                   return (
                     <li key={tx._id} className="py-2">
-                      <div className="flex w-full justify-between font-inter">
+                      <div className="flex w-full justify-between">
                         <span className="font-semibold">
                           {getCategoryLabel(tx.category)}
                         </span>
@@ -208,6 +209,8 @@ export default function DashboardPage() {
             </ul>
           )}
         </section>
+
+        <TransactionInfoCard />
       </div>
     </>
   );

--- a/frontend/src/app/page.tsx
+++ b/frontend/src/app/page.tsx
@@ -1,6 +1,5 @@
 "use client";
 
-import TransactionInfoCard from "../components/ui/TransactionInfoCard";
 import HeroSection from "../components/ui/Homepage/HeroSection";
 import Navbar from "../components/ui/Homepage/Navbar";
 
@@ -10,7 +9,6 @@ export default function Home() {
       <main className="h-screen w-full bg-light text-dark transition-all duration-1000 dark:bg-white/10 dark:text-white">
         <Navbar />
         <HeroSection />
-        <TransactionInfoCard />
       </main>
     </>
   );

--- a/frontend/src/app/page.tsx
+++ b/frontend/src/app/page.tsx
@@ -1,5 +1,6 @@
 "use client";
 
+import TransactionInfoCard from "../components/ui/TransactionInfoCard";
 import HeroSection from "../components/ui/Homepage/HeroSection";
 import Navbar from "../components/ui/Homepage/Navbar";
 
@@ -9,6 +10,7 @@ export default function Home() {
       <main className="h-screen w-full bg-light text-dark transition-all duration-1000 dark:bg-white/10 dark:text-white">
         <Navbar />
         <HeroSection />
+        <TransactionInfoCard />
       </main>
     </>
   );

--- a/frontend/src/components/forms/SubscriptionModal.tsx
+++ b/frontend/src/components/forms/SubscriptionModal.tsx
@@ -120,7 +120,7 @@ export default function SubscriptionModal({
               decimalScale={2}
               allowNegative={false}
               suffix={` ${currencyType}`}
-              className="mt-1 w-full rounded border px-3 py-2 font-inter outline-none"
+              className="mt-1 w-full rounded border px-3 py-2 outline-none"
               placeholder={`1.00 ${currencyType}`}
               required
               value={amount}

--- a/frontend/src/components/ui/RemindersCard.tsx
+++ b/frontend/src/components/ui/RemindersCard.tsx
@@ -17,17 +17,17 @@ export default function RemindersCard({
   return (
     <li
       onClick={() => onClick(reminder)}
-      className="dark:bg-light/10 font-inter hover:dark:bg-light/20 flex max-w-max cursor-pointer flex-col gap-1 rounded-md bg-light px-3 py-2 shadow-md transition-all duration-1000 hover:opacity-60"
+      className="flex max-w-max cursor-pointer flex-col gap-1 rounded-md bg-light px-3 py-2 shadow-md transition-all duration-1000 hover:opacity-60 dark:bg-light/10 hover:dark:bg-light/20"
     >
       <span className="font-zona-pro font-medium md:text-lg">
         {reminder.title}
       </span>
       {reminder.description && (
-        <p className="text-dark/50 dark:text-light/40 font-archivo text-xs transition-all duration-1000 md:text-sm">
+        <p className="font-archivo text-xs text-dark/50 transition-all duration-1000 dark:text-light/40 md:text-sm">
           {reminder.description}
         </p>
       )}
-      <span className="dark:text-light/60 text-dark/70 text-xs font-medium transition-all duration-1000">
+      <span className="text-xs font-medium text-dark/70 transition-all duration-1000 dark:text-light/60">
         {format(new Date(reminder.date), "dd/MM/yyyy")}
       </span>
     </li>

--- a/frontend/src/components/ui/SubscriptionsCard.tsx
+++ b/frontend/src/components/ui/SubscriptionsCard.tsx
@@ -123,7 +123,7 @@ export default function SubscriptionsCard({
             <PencilIcon size={16} className="text-dark/70" />
           </ListItemIcon>
           <ListItemText>
-            <span className="font-inter! text-sm font-light">Editar</span>
+            <span className="text-sm font-light">Editar</span>
           </ListItemText>
         </MenuItem>
         <MenuItem onClick={handleDelete}>
@@ -131,7 +131,7 @@ export default function SubscriptionsCard({
             <Trash2Icon size={16} className="text-dark/70" />
           </ListItemIcon>
           <ListItemText>
-            <span className="font-inter! text-sm font-light">Deletar</span>
+            <span className="text-sm font-light">Deletar</span>
           </ListItemText>
         </MenuItem>
       </Menu>

--- a/frontend/src/components/ui/TransactionInfoCard.tsx
+++ b/frontend/src/components/ui/TransactionInfoCard.tsx
@@ -1,23 +1,85 @@
 import React from "react";
-import TitlePage from "../common/TitlePage";
 import { XIcon } from "lucide-react";
 
-const TransactionInfoCard = () => {
+import type { Transaction } from "@/src/store/useTransactionStore";
+import type { Bank } from "@/src/store/useBankStore";
+
+import { getCategoryLabel } from "@/src/utils/getCategoryLabels";
+import { formatCurrency } from "@/src/utils/format-currency";
+
+type ResolveBankFn = (tx: Transaction) => {
+  bankName: string | null;
+  bankCurrency: string | null;
+};
+
+interface Props {
+  transaction: Transaction;
+  onClose: () => void;
+  resolveBankInfo?: ResolveBankFn;
+  banks?: Bank[];
+}
+
+export default function TransactionInfoCard({
+  transaction,
+  onClose,
+  resolveBankInfo,
+}: Props) {
+  const tx = transaction;
+
+  let bankName: string | null = null;
+  let bankCurrency: string | null = null;
+  if (resolveBankInfo) {
+    const info = resolveBankInfo(tx);
+    bankName = info.bankName;
+    bankCurrency = info.bankCurrency;
+  } else if (tx.bank && typeof tx.bank === "object") {
+    const b = tx.bank as any;
+    bankName = b.bankName ?? null;
+    bankCurrency = b.currencyType ?? null;
+  }
+
+  const amountFormatted = formatCurrency(tx.amount);
+  const sign = tx.type === "expense" ? "-" : "+";
+  const categoryLabel = getCategoryLabel(tx.category);
+
   return (
-    <div className="bg-grey mx-auto mt-20 w-full rounded-2xl bg-white p-3 shadow-sm dark:bg-black">
-      <div className="flex items-start justify-between">
-        <TitlePage text="Título" />
-        <button>
-          <XIcon />
-        </button>
-      </div>
-      <p className="text-sm opacity-60">Aqui será a descrição da transação.</p>
-      <div className="mt-10 flex w-full items-end justify-between">
-        <span className="font-zona-pro text-xl font-bold">25,40 GBP</span>
-        <span className="text-sm opacity-50">Wise</span>
+    <div
+      className="fixed inset-0 z-50 flex items-start justify-center px-4 py-8"
+      role="dialog"
+      aria-modal="true"
+    >
+      <div
+        className="absolute inset-0 bg-black/30 backdrop-blur-sm"
+        onClick={onClose}
+      />
+
+      <div className="relative z-10 w-full max-w-md rounded-xl bg-white p-4 shadow-xl dark:bg-dark/90">
+        <div className="flex items-start justify-between">
+          <div>
+            <h3 className="text-lg font-semibold">{categoryLabel}</h3>
+            {transaction.description && (
+              <p className="mt-1 text-sm text-neutral-500">
+                {transaction.description}
+              </p>
+            )}
+          </div>
+
+          <button
+            onClick={onClose}
+            aria-label="Fechar"
+            className="ml-4 rounded-full p-1 hover:bg-black/5 dark:hover:bg-white/5"
+          >
+            <XIcon />
+          </button>
+        </div>
+
+        <div className="mt-6 flex items-center justify-between">
+          <div className="font-zona-pro text-2xl font-bold">
+            {sign} {amountFormatted} {bankCurrency ?? ""}
+          </div>
+          <div className="text-sm text-neutral-500">{bankName ?? "—"}</div>
+        </div>
       </div>
     </div>
   );
-};
-
-export default TransactionInfoCard;
+}

--- a/frontend/src/components/ui/TransactionInfoCard.tsx
+++ b/frontend/src/components/ui/TransactionInfoCard.tsx
@@ -1,10 +1,22 @@
 import React from "react";
+import TitlePage from "../common/TitlePage";
+import { XIcon } from "lucide-react";
 
 const TransactionInfoCard = () => {
   return (
-    <section className="mx-auto mt-20 max-w-[343px] bg-red-500 text-center">
-      TransactionInfoCard
-    </section>
+    <div className="bg-grey mx-auto mt-20 w-full rounded-2xl bg-white p-3 shadow-sm dark:bg-black">
+      <div className="flex items-start justify-between">
+        <TitlePage text="Título" />
+        <button>
+          <XIcon />
+        </button>
+      </div>
+      <p className="text-sm opacity-60">Aqui será a descrição da transação.</p>
+      <div className="mt-10 flex w-full items-end justify-between">
+        <span className="font-zona-pro text-xl font-bold">25,40 GBP</span>
+        <span className="text-sm opacity-50">Wise</span>
+      </div>
+    </div>
   );
 };
 

--- a/frontend/src/components/ui/TransactionInfoCard.tsx
+++ b/frontend/src/components/ui/TransactionInfoCard.tsx
@@ -1,0 +1,11 @@
+import React from "react";
+
+const TransactionInfoCard = () => {
+  return (
+    <section className="mx-auto mt-20 max-w-[343px] bg-red-500 text-center">
+      TransactionInfoCard
+    </section>
+  );
+};
+
+export default TransactionInfoCard;


### PR DESCRIPTION
From now on, the `/dashboard` page has the `TransactionInfoCard` component, rendering all of info's transaction choosed by user.

The design:

<img width="660" height="231" alt="image" src="https://github.com/user-attachments/assets/03230d0a-4426-4296-bbf9-5e0ce0fea985" />
